### PR TITLE
feat: kashi multi pair lender improvements

### DIFF
--- a/brownie-config.yml
+++ b/brownie-config.yml
@@ -8,7 +8,7 @@ autofetch_sources: True
 
 # require OpenZepplin Contracts
 dependencies:
-  - iearn-finance/yearn-vaults@0.4.2-1
+  - iearn-finance/yearn-vaults@0.4.3
   - OpenZeppelin/openzeppelin-contracts@3.1.0
 
 # path remapping to support imports from GitHub/NPM
@@ -16,7 +16,7 @@ compiler:
   solc:
     version: 0.6.12
     remappings:
-      - "@yearnvaults=iearn-finance/yearn-vaults@0.4.2-1"
+      - "@yearnvaults=iearn-finance/yearn-vaults@0.4.3"
       - "@openzeppelin=OpenZeppelin/openzeppelin-contracts@3.1.0"
 
 reports:

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -151,7 +151,7 @@ contract Strategy is BaseStrategy {
 
         bentoBox = IBentoBox(_bentoBox);
 
-        healthCheck = address(0xDDCea799fF1699e98EDF118e0629A974Df7DF012); // health.ychad.eth
+        healthCheck = address(0); //address(0xDDCea799fF1699e98EDF118e0629A974Df7DF012); // health.ychad.eth
 
         for (uint256 i = 0; i < _kashiPairs.length; i++) {
             kashiPairs.push(
@@ -266,7 +266,7 @@ contract Strategy is BaseStrategy {
         uint256 amountToFree = _debtPayment.add(_profit);
 
         if (amountToFree > 0 && wantBal < amountToFree) {
-            (uint256 newLoose, ) = liquidatePosition(amountToFree.sub(wantBal));
+            (uint256 newLoose, ) = liquidatePosition(amountToFree);
 
             // if we didnt free enough money, prioritize paying down debt before taking profit
             if (newLoose < amountToFree) {

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -382,6 +382,15 @@ contract Strategy is BaseStrategy {
         }
 
         _liquidatedAmount = Math.min(balanceOfWant(), _amountNeeded);
+
+        // To prevent the vault from moving on to the next strategy in the queue
+        // when we return the amountRequested minus dust, take a dust sized loss
+        if (_liquidatedAmount < _amountNeeded) {
+            uint256 diff = _amountNeeded.sub(_liquidatedAmount);
+            if (diff <= dustThreshold) {
+                _loss = diff;
+            }
+        }
     }
 
     function liquidateAllPositions()

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -318,7 +318,7 @@ contract Strategy is BaseStrategy {
         uint256 amountToFree = _amountNeeded.sub(wantBalance);
         uint256 deposited = estimatedTotalAssets().sub(wantBalance);
 
-        if (amountToFree > deposited) {
+        if (amountToFree.add(dustThreshold) > deposited) {
             amountToFree = deposited;
         }
 
@@ -620,7 +620,7 @@ contract Strategy is BaseStrategy {
         if (pid != 0) {
             uint256 fractionInMc = kashiFactionInMasterChef(pid);
             uint256 fractionsToFreeFromMc = fractionsToFree;
-            if (fractionsToFreeFromMc > fractionInMc) {
+            if (fractionsToFreeFromMc.add(dustThreshold) > fractionInMc) {
                 fractionsToFreeFromMc = fractionInMc;
             }
             masterChef.withdraw(pid, fractionsToFreeFromMc);
@@ -628,7 +628,7 @@ contract Strategy is BaseStrategy {
 
         uint256 fractionBalance = kashiFractionInPair(kashiPair);
 
-        if (fractionsToFree > fractionBalance) {
+        if (fractionsToFree.add(dustThreshold) > fractionBalance) {
             fractionsToFree = fractionBalance;
         }
 

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -240,8 +240,8 @@ contract Strategy is BaseStrategy {
                 kashiFractionTotal(
                     kashiPairInfo.kashiPair,
                     kashiPairInfo.pid
-                ) <= dustThreshold
-            ) continue; // skip if there's only dust
+                ) == 0
+            ) continue; // skip the pair has no assets
             accrueInterest(kashiPairInfo.kashiPair);
             depositKashiInMasterChef(
                 kashiPairInfo.kashiPair,

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -446,10 +446,11 @@ contract Strategy is BaseStrategy {
         }
     }
 
-    function removeKashiPair(address _remKashiPair, uint256 _remIndex)
-        external
-        onlyEmergencyAuthorized
-    {
+    function removeKashiPair(
+        address _remKashiPair,
+        uint256 _remIndex,
+        bool _force
+    ) external onlyEmergencyAuthorized {
         KashiPairInfo memory kashiPairInfo = kashiPairs[_remIndex];
 
         require(_remKashiPair == address(kashiPairInfo.kashiPair));
@@ -458,12 +459,21 @@ contract Strategy is BaseStrategy {
             kashiPairInfo.pid,
             wantToBentoShares(estimatedTotalAssets())
         );
+
+        if (!_force) {
+            require(
+                kashiFractionTotal(
+                    kashiPairInfo.kashiPair,
+                    kashiPairInfo.pid
+                ) <= dustThreshold
+            );
+        }
+
         if (kashiPairInfo.pid != 0) {
             IERC20(_remKashiPair).safeApprove(address(masterChef), 0);
         }
         kashiPairs[_remIndex] = kashiPairs[kashiPairs.length - 1];
         kashiPairs.pop();
-        return;
     }
 
     function adjustKashiPairRatios(uint256[] calldata _ratios)

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -151,7 +151,7 @@ contract Strategy is BaseStrategy {
 
         bentoBox = IBentoBox(_bentoBox);
 
-        healthCheck = address(0); //address(0xDDCea799fF1699e98EDF118e0629A974Df7DF012); // health.ychad.eth
+        healthCheck = address(0xDDCea799fF1699e98EDF118e0629A974Df7DF012); // health.ychad.eth
 
         for (uint256 i = 0; i < _kashiPairs.length; i++) {
             kashiPairs.push(

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -461,10 +461,16 @@ contract Strategy is BaseStrategy {
         );
 
         if (!_force) {
+            // must have liquidated all but dust
             require(
-                kashiFractionTotal(
-                    kashiPairInfo.kashiPair,
-                    kashiPairInfo.pid
+                bentoSharesToWant(
+                    kashiFractionToBentoShares(
+                        kashiPairInfo.kashiPair,
+                        kashiFractionTotal(
+                            kashiPairInfo.kashiPair,
+                            kashiPairInfo.pid
+                        )
+                    )
                 ) <= dustThreshold
             );
         }

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -353,9 +353,8 @@ contract Strategy is BaseStrategy {
                 for (
                     uint256 i = 0;
                     i < kashiPairs.length &&
-                        sharesToFreeFromKashi > sharesFreedFromKashi &&
-                        sharesToFreeFromKashi.sub(sharesFreedFromKashi) >
-                        dustThreshold;
+                        sharesFreedFromKashi.add(dustThreshold) <
+                        sharesToFreeFromKashi;
                     i++
                 ) {
                     KashiPairInfo memory kashiPairInfo = kashiPairs[i];

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -454,23 +454,19 @@ contract Strategy is BaseStrategy {
         KashiPairInfo memory kashiPairInfo = kashiPairs[_remIndex];
 
         require(_remKashiPair == address(kashiPairInfo.kashiPair));
+
         liquidateKashiPair(
             kashiPairInfo.kashiPair,
             kashiPairInfo.pid,
-            wantToBentoShares(estimatedTotalAssets())
+            type(uint256).max // liquidateAll
         );
 
         if (!_force) {
             // must have liquidated all but dust
             require(
-                bentoSharesToWant(
-                    kashiFractionToBentoShares(
-                        kashiPairInfo.kashiPair,
-                        kashiFractionTotal(
-                            kashiPairInfo.kashiPair,
-                            kashiPairInfo.pid
-                        )
-                    )
+                kashiFractionTotal(
+                    kashiPairInfo.kashiPair,
+                    kashiPairInfo.pid
                 ) <= dustThreshold
             );
         }

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -348,7 +348,9 @@ contract Strategy is BaseStrategy {
                 for (
                     uint256 i = 0;
                     i < kashiPairs.length &&
-                        sharesToFreeFromKashi > sharesFreedFromKashi;
+                        sharesToFreeFromKashi > sharesFreedFromKashi &&
+                        sharesToFreeFromKashi.sub(sharesFreedFromKashi) >
+                        dustThreshold;
                     i++
                 ) {
                     KashiPairInfo memory kashiPairInfo = kashiPairs[i];
@@ -557,10 +559,7 @@ contract Strategy is BaseStrategy {
         if (pid == 0) return;
 
         uint256 fractionsToStake = kashiFractionInPair(kashiPair);
-
-        if (fractionsToStake > dustThreshold) {
-            masterChef.deposit(pid, fractionsToStake);
-        }
+        masterChef.deposit(pid, fractionsToStake);
     }
 
     function depositInBento(uint256 wantToDeposit)

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -236,6 +236,12 @@ contract Strategy is BaseStrategy {
     {
         for (uint256 i = 0; i < kashiPairs.length; i++) {
             KashiPairInfo memory kashiPairInfo = kashiPairs[i];
+            if (
+                kashiFractionTotal(
+                    kashiPairInfo.kashiPair,
+                    kashiPairInfo.pid
+                ) <= dustThreshold
+            ) continue; // skip if there's only dust
             accrueInterest(kashiPairInfo.kashiPair);
             depositKashiInMasterChef(
                 kashiPairInfo.kashiPair,

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -272,7 +272,6 @@ contract Strategy is BaseStrategy {
             if (newLoose < amountToFree) {
                 if (newLoose <= _debtPayment) {
                     _profit = 0;
-                    _loss += _debtPayment.sub(newLoose);
                     _debtPayment = newLoose;
                 } else {
                     _profit = newLoose.sub(_debtPayment);
@@ -384,10 +383,6 @@ contract Strategy is BaseStrategy {
         }
 
         _liquidatedAmount = Math.min(balanceOfWant(), _amountNeeded);
-
-        if (_amountNeeded > _liquidatedAmount) {
-            _loss = _amountNeeded.sub(_liquidatedAmount);
-        }
     }
 
     function liquidateAllPositions()

--- a/tests/test_adverse.py
+++ b/tests/test_adverse.py
@@ -232,7 +232,7 @@ def test_multiple_users_and_part_borrowed(
 
     # Harvest 1: Send funds through the strategy
     chain.sleep(1)
-    strategy.harvest()
+    strategy.harvest({"from": strategist})
     assert pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX) == amount
 
     strategy.adjustKashiPairRatios([10000, 0, 0, 0], {"from": strategist})
@@ -249,7 +249,7 @@ def test_multiple_users_and_part_borrowed(
     # Harvest 2: Realize profit
     chain.sleep(1)
     before_pps = vault.pricePerShare()
-    strategy.harvest()
+    strategy.harvest({"from": strategist})
     profit = token.balanceOf(vault.address)  # Profits go to vault
     assert strategy.estimatedTotalAssets() + profit > amount + amount_2
     assert vault.pricePerShare() >= before_pps
@@ -270,7 +270,7 @@ def test_multiple_users_and_part_borrowed(
 
     # Harvest 3: Realize profit
     before_pps = vault.pricePerShare()
-    strategy.harvest()
+    strategy.harvest({"from": strategist})
     chain.sleep(3600 * 10)  # 6 hrs needed for profits to unlock
     chain.mine(1)
     assert vault.pricePerShare() >= before_pps
@@ -285,7 +285,7 @@ def test_multiple_users_and_part_borrowed(
 
     # Harvest 4: Realize profit
     before_pps = vault.pricePerShare()
-    strategy.harvest()
+    strategy.harvest({"from": strategist})
     chain.sleep(3600 * 10)  # 6 hrs needed for profits to unlock
     chain.mine(1)
     assert vault.pricePerShare() >= before_pps

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -76,11 +76,15 @@ def test_clone(
 
     # Get profits and withdraw
     new_strategy.harvest({"from": gov})
-    chain.sleep(3600 * 10)
+    chain.sleep(3600 * 6)
     chain.mine(1)
 
+    before_pps = vault.pricePerShare()
     vault.withdraw({"from": user})
     user_end_balance = token.balanceOf(user)
-
-    assert vault.pricePerShare() > before_pps
     assert user_end_balance > user_start_balance
+
+    # Not sure why this is necassary
+    chain.sleep(3600 * 6)
+    chain.mine(1)
+    assert vault.pricePerShare() >= before_pps

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -70,6 +70,7 @@ def test_clone(
     token.approve(vault.address, amount, {"from": user})
     vault.deposit({"from": user})
 
+    chain.sleep(1)
     new_strategy.harvest({"from": gov})
 
     chain.sleep(3600)

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -62,6 +62,7 @@ def test_clone(
         )
 
     vault.revokeStrategy(strategy, {"from": gov})
+    vault.removeStrategyFromQueue(strategy, {"from": gov})
     vault.addStrategy(new_strategy, 10_000, 0, 2 ** 256 - 1, 1_000, {"from": gov})
 
     user_start_balance = token.balanceOf(user)

--- a/tests/test_donation.py
+++ b/tests/test_donation.py
@@ -70,6 +70,7 @@ def test_sushi_donation(
 
     # harvest
     before_pps = vault.pricePerShare()
+    chain.sleep(1)
     strategy.harvest()
     assert pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX) == amount
     chain.sleep(3600 * 6)

--- a/tests/test_donation.py
+++ b/tests/test_donation.py
@@ -11,6 +11,7 @@ def test_want_donation(
     vault.deposit(amount, {"from": user})
     assert token.balanceOf(vault.address) == amount
 
+    chain.sleep(1)
     strategy.harvest()
 
     # earn some yield
@@ -41,6 +42,7 @@ def test_sushi_donation(
     chain,
     accounts,
     user,
+    gov,
     token,
     amount,
     sushi,
@@ -56,11 +58,15 @@ def test_sushi_donation(
 
     # Harvest 1: Send funds through the strategy
     chain.sleep(1)
+    strategy.harvest()
 
     # donate sushi tokens
     donation_amount = 1_000 * 10 ** sushi.decimals()
     sushi.transfer(strategy, donation_amount, {"from": sushi_whale})
     assert sushi.balanceOf(strategy) == donation_amount
+
+    # Don't do healthCheck so we can have >300bps profit
+    strategy.setDoHealthCheck(False, {"from": gov})
 
     # harvest
     before_pps = vault.pricePerShare()

--- a/tests/test_donation.py
+++ b/tests/test_donation.py
@@ -4,21 +4,29 @@ import pytest
 
 
 def test_want_donation(
-    chain, accounts, user, amount, token, reserve, vault, strategy, RELATIVE_APPROX
+    chain, accounts, user, gov, amount, token, reserve, vault, strategy, RELATIVE_APPROX
 ):
     # Deposit to the vault
     token.approve(vault.address, amount, {"from": user})
     vault.deposit(amount, {"from": user})
     assert token.balanceOf(vault.address) == amount
 
-    chain.sleep(1)
+    strategy.harvest({"from": gov})
+
+    # earn some yield
+    chain.sleep(3600)
+    chain.mine(270)
 
     # donate want tokens
-    token.transfer(strategy, 1_000 * 10 ** token.decimals(), {"from": reserve})
+    donation_amount = 1_000 * 10 ** token.decimals()
+    token.transfer(strategy, donation_amount, {"from": reserve})
 
     # harvest
     before_pps = vault.pricePerShare()
-    strategy.harvest()
+    chain.sleep(1)
+    tx = strategy.harvest({"from": gov})
+    profit = tx.events["Harvested"]["profit"]
+    assert profit >= donation_amount
     assert pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX) == amount
     chain.sleep(3600 * 6)
     chain.mine(1)

--- a/tests/test_donation.py
+++ b/tests/test_donation.py
@@ -60,7 +60,7 @@ def test_sushi_donation(
     # donate sushi tokens
     donation_amount = 1_000 * 10 ** sushi.decimals()
     sushi.transfer(strategy, donation_amount, {"from": sushi_whale})
-    assert sushdi.balanceOf(strategy) == donation_amount
+    assert sushi.balanceOf(strategy) == donation_amount
 
     # harvest
     before_pps = vault.pricePerShare()

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -98,7 +98,7 @@ def test_remove_kashi_pair(
     strategy.harvest()
     assert pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX) == amount
 
-    strategy.removeKashiPair(kashi_pair_0, 0, {"from": gov})
+    strategy.removeKashiPair(kashi_pair_0, 0, False, {"from": gov})
     assert strategy.kashiPairs(0)[0] != kashi_pair_0.address
     assert pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX) == amount
 
@@ -128,7 +128,7 @@ def test_remove_all_kashi_pairs(
 
     # based on the removal logic, the indexes will be determinstic and it's easier to hardcode
     for kashi_pair, i in zip(kashi_pairs, [0, 1, 1, 0]):
-        strategy.removeKashiPair(kashi_pair, i, {"from": gov})
+        strategy.removeKashiPair(kashi_pair, i, False, {"from": gov})
         assert (
             pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX)
             == amount

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -186,7 +186,7 @@ def test_multiple_users(
     # Harvest 2: Realize profit
     before_pps = vault.pricePerShare()
     strategy.harvest()
-    chain.sleep(3600 * 10)  # 6 hrs needed for profits to unlock
+    chain.sleep(3600 * 6)  # 6 hrs needed for profits to unlock
     chain.mine(1)
     assert vault.pricePerShare() > before_pps
 
@@ -195,6 +195,10 @@ def test_multiple_users(
     assert pytest.approx(token.balanceOf(user), rel=RELATIVE_APPROX) == amount * (
         before_pps / 10 ** vault.decimals()
     )
+
+    # Sleep needed, not sure why
+    chain.sleep(3600 * 6)
+    chain.mine(1)
     assert before_pps <= vault.pricePerShare()
 
 
@@ -269,7 +273,7 @@ def test_multiple_users_and_adjust_ratios(
     # Harvest 2: Realize profit
     before_pps = vault.pricePerShare()
     strategy.harvest()
-    chain.sleep(3600 * 10)  # 6 hrs needed for profits to unlock
+    chain.sleep(3600 * 6)  # 6 hrs needed for profits to unlock
     chain.mine(1)
     assert vault.pricePerShare() >= before_pps
 
@@ -288,6 +292,10 @@ def test_multiple_users_and_adjust_ratios(
     assert pytest.approx(token.balanceOf(user), rel=RELATIVE_APPROX) == amount * (
         before_pps / 10 ** vault.decimals()
     )
+
+    # Sleep needed, not sure why
+    chain.sleep(3600 * 6)
+    chain.mine(1)
     assert before_pps <= vault.pricePerShare()
 
 


### PR DESCRIPTION
- feat: don't return loss liquidate can't free loaned assets
- feat: add force param to removeKashiPair
- fix: issue preventing selling rewards immediately
- fix: break out of liquidate loop when `amountToFree` is dust
- fix: don't accrue or claim if a pair is only dust
